### PR TITLE
Fix JSHint warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@ Dustin Willis Webber <dustin.webber@gmail.com>
 # And thanks for contributions from:
 
 Eugene Bulkin <eugene@eugenebulkin.name>
+Jeff Hubbard <lord2800@gmail.com>
 Shadab Zafar <dufferzafar0@gmail.com>

--- a/app/client.js
+++ b/app/client.js
@@ -287,7 +287,7 @@ define([
         $('.channel[data-server-id="'+self.options.uuid+'"][data-name="'+channel+'"] .topic span.title').html(topic);
         self.addMessage(channel, "Topic: " + (topic || "N/A"));
 
-        Komanda.vent.trigger(self.options.uuid + ":" + channel + ":topic", (topic || "N/A"))
+        Komanda.vent.trigger(self.options.uuid + ":" + channel + ":topic", (topic || "N/A"));
         Komanda.vent.trigger('topic', data);
       }
 
@@ -761,9 +761,9 @@ define([
       if (Komanda.settings.get("notifications.badge") && Komanda.window.setBadgeLabel) {
         var masterCount = 0;
 
-        for (server in Komanda.store) {
-          var chans = Komanda.store[server].count
-          for (chan in chans) {
+        for (var store in Komanda.store) {
+          var chans = Komanda.store[store].count;
+          for (var chan in chans) {
             var count = chans[chan];
             if (count) masterCount += count; 
           }


### PR DESCRIPTION
While trying to build this morning, I ran into the following JSHint warnings (which failed the build--one of which probably signified an actual problem: reusing the `server` variable):

```
Running "jshint:all" (jshint) task
Linting app/client.js ...ERROR
[L290:C93] W033: Missing semicolon.
        Komanda.vent.trigger(self.options.uuid + ":" + channel + ":topic", (topic || "N/A"))
[L765:C37] W038: 'server' used out of scope.
          var chans = Komanda.store[server].count
[L765:C50] W033: Missing semicolon.
          var chans = Komanda.store[server].count
[L766:C16] W088: Creating global 'for' variable. Should be 'for (var chan ...'.
          for (chan in chans) {
```
