### PR TITLE
fix inability to click titlebar buttons on windows

### DIFF
--- a/app/styles/komanda.css
+++ b/app/styles/komanda.css
@@ -271,6 +271,7 @@ border-radius: 100px 100px 100px 100px;
 	display: inline-block;
 	float: left;
 	margin-right: 5px;
+    -webkit-app-region: no-drag;
 }
 
 /*#header .window-controls .window-button.close,*/


### PR DESCRIPTION
Oddly enough this worked fine on OS X, but the -webkit-app-region rule on the whole titlebar made the buttons unclickable in windows.
