### PR TITLE
Fixed #71: Don't attempt to auto-join if no channels specified

### DIFF
--- a/app/lib/layout/sidebar.js
+++ b/app/lib/layout/sidebar.js
@@ -119,7 +119,9 @@ define([
               } else {
                 connect.start(function(client) {
                   _.each(session.get('channels'), function(c) {
-                    Komanda.vent.trigger(uuid + ":join", c);
+                    if (c.trim().length > 0) {
+                      Komanda.vent.trigger(uuid + ":join", c);
+                    }
                   });
                 });
               };

--- a/app/lib/sessions/session-edit-view.js
+++ b/app/lib/sessions/session-edit-view.js
@@ -59,7 +59,9 @@ define([
       if (self.model.get('connectOnStart')) {
         connect.start(function(client) {
           _.each(self.model.get('channels'), function(c) {
-            Komanda.vent.trigger(self.model.get('uuid') + ":join", c.trim());
+            if (c.trim().length > 0) {
+              Komanda.vent.trigger(self.model.get('uuid') + ":join", c.trim());
+            }
           });
         });
       }

--- a/app/main.js
+++ b/app/main.js
@@ -180,7 +180,9 @@ requirejs(["config"], function(require) {
           if (m.get("connectOnStart")) {
             connect.start(function(client) {
               _.each(m.get("channels"), function(c) {
-                Komanda.vent.trigger(m.get("uuid") + ":join", c);
+                if (c.trim().length > 0) {
+                  Komanda.vent.trigger(m.get("uuid") + ":join", c);
+                }
               });
             });
           }


### PR DESCRIPTION
Fix for #71.

On connect, before autojoining channels check that the channel provided isn't an empty string.
