### PR TITLE
Fixed #98: Listen for emitted "action" signals and display them using sendMessage

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -922,7 +922,7 @@ define([
 
   };
 
-  Client.prototype.sendMessage = function(nick, to, text, message, flip, isNotice) {
+  Client.prototype.sendMessage = function(nick, to, text, message, flip, isNotice, isAction) {
     var self = this;
 
     var data = {
@@ -933,7 +933,8 @@ define([
       server: self.options.uuid,
       uuid: uuid.v4(),
       timestamp: moment().format(Komanda.settings.get("display.timestamp")),
-      flip: flip
+      flip: flip,
+      isAction: isAction
     };
 
     if (text.match(self.nick) && !self.me(nick)) {

--- a/app/templates/message.hbs
+++ b/app/templates/message.hbs
@@ -8,7 +8,7 @@
 
     {{#if nick}}
     <span class="nickname {{#if highlight}}highlight{{/if}}" style="color:{{random-color nick }}">
-      {{nick}}:
+      {{nick}}{{#unless isAction}}:{{/unless}}
     </span>
     {{else}}
     <span class="nickname {{#unless nick}}system-message{{/unless}}">


### PR DESCRIPTION
Fix for #98.

node-irc emits 'action' signals, this PR adds a listener for these emitted actions and treats them like messages.
Using the same Message object/template with an added check to remove the colon between the nick and action text.
