### PR TITLE
Clickable sha link for GithubItem commit link

### DIFF
--- a/app/templates/plugins/github/feed-item.hbs
+++ b/app/templates/plugins/github/feed-item.hbs
@@ -123,7 +123,7 @@
         <ul class="commits">
           {{#payload.commits}}
           <li>
-            <code style="margin-bottom:5px;">{{sha}}</code> {{message}}<br />
+            <code style="margin-bottom:5px;"><a href="https://github.com/{{../repo.name}}/commit/{{sha}}">{{sha}}</a></code> {{message}}<br />
           </li>
           {{/payload.commits}}
         </ul>


### PR DESCRIPTION
Made the sha link in commit messages an href pointing to the commit page on github.
