### PR TITLE
Linked directly to the pull request page on github

### DIFF
--- a/app/templates/plugins/github/feed-item.hbs
+++ b/app/templates/plugins/github/feed-item.hbs
@@ -175,7 +175,7 @@
           <strong>{{actor.login}}</strong> 
         </a>
         {{payload.action}} pull request
-        <a href="https://github.com/{{repo.name}}">{{repo.name}}#{{payload.number}}</a>
+        <a href="https://github.com/{{repo.name}}/pull/{{payload.number}}">{{repo.name}}#{{payload.number}}</a>
       </div>
 
       <div class="github-body">


### PR DESCRIPTION
Changed the link built for PullEvent GithubFeedItems to point directly to the pull request's page.
