### PR TITLE
Fixed 'grunt run' on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,7 +229,7 @@ module.exports = function(grunt) {
 
     exec: {
       win: {
-        cmd: "build/cache/win/<%= nodewebkit.options.version %>/nw.exed ."
+        cmd: '"build/cache/win/<%= nodewebkit.options.version %>/nw.exe" .'
       },
       mac: {
         cmd: "build/cache/mac/<%= nodewebkit.options.version %>/node-webkit.app/Contents/MacOS/node-webkit ."


### PR DESCRIPTION
There was a typo and I had to add quotes around the command so Windows
could find it.

Before fixing, I got this error:

``` bash
$ grunt run
Building 0.1.1-beta

Running "run" task

Running "exec:win" (exec) task
>> 'build' is not recognized as an internal or external command,
>> operable program or batch file.
>> Exited with code: 1.
Warning: Task "exec:win" failed. Use --force to continue.

Aborted due to warnings.
```
