### PR TITLE
Add display.system setting

### DIFF
--- a/app/helpers.js
+++ b/app/helpers.js
@@ -55,6 +55,15 @@ define([
       });
     },
 
+    toggleSystemMessage: function (show) {
+      $("head style#display-system").remove();
+      if (!show) {
+        var style = $("<style id=\"display-system\" type=\"text/css\">");
+        $("head").append(style);
+        style[0].sheet.insertRule("div.message.system-message { display: none; }", 0);
+      }
+    },
+
     loadTheme: function(settings, callback) {
       var key = settings.themes.current; 
 

--- a/app/lib/settings.js
+++ b/app/lib/settings.js
@@ -44,7 +44,8 @@ define([
         badge: true
       },
       display: {
-        timestamp: "MM/DD/YY hh:mm:ss"
+        timestamp: "MM/DD/YY hh:mm:ss",
+        system: true
       },
       sounds: {
         chat: false,
@@ -67,6 +68,10 @@ define([
         // Komanda.settings.save(null);
 
         if (a.changed.hasOwnProperty("themes")) Helpers.loadTheme(a.attributes);
+      });
+
+      this.bind("change:display.system", function(model, newValue) {
+        Helpers.toggleSystemMessage(newValue);
       });
     }
   });

--- a/app/templates/message.hbs
+++ b/app/templates/message.hbs
@@ -1,4 +1,4 @@
-<div class="message {{#if highlight}}highlight{{/if}}">
+<div class="message {{#if highlight}}highlight{{/if}} {{#unless nick}}system-message{{/unless}}">
 
   <div class="body">
 

--- a/app/templates/notice.hbs
+++ b/app/templates/notice.hbs
@@ -1,4 +1,4 @@
-<div class="message {{#if highlight}}highlight{{/if}}">
+<div class="message {{#if highlight}}highlight{{/if}} {{#unless nick}}system-message{{/unless}}">
 
   <div class="body">
 

--- a/app/templates/settings/komanda.hbs
+++ b/app/templates/settings/komanda.hbs
@@ -69,4 +69,9 @@
     <input id="komanda-settings-quit-message" type="text" name="messages.quit" value="{{messages.quit}}" placeholder="Komanda - The IRC Client For Developers http://komanda.io">
   </div>
 
+  <div class="form-box">
+    <label for="komanda-settings-hide-system-messages">Show System Messages</label>
+    <input id="komanda-settings-hide-system-messages" type="checkbox" name="display.system">
+  </div>
+
 </div>


### PR DESCRIPTION
It toggles shown/hide of system messages, such as `quit`, `join` etc.
