### PR TITLE
Don't scroll to bottom on entering channel

### DIFF
--- a/app/lib/channels/channels-view.js
+++ b/app/lib/channels/channels-view.js
@@ -82,9 +82,6 @@ define([
       var select = ".channel-holder .channel[data-server-id=\"" + server + "\"][data-name=\"" + channel + "\"]";
       $(select).show();
 
-      var objDiv = $(select).find(".messages").get(0);
-      if (objDiv) objDiv.scrollTop = objDiv.scrollHeight;
-
       $(select).find("input").focus();
     },
 


### PR DESCRIPTION
When entering on channel with a lot of new messages, we lost the last reading position because scroll bar go to the bottom. This commit will fix that problem.
