### PR TITLE
Empty (Cancelling) Chat Color Code Functionality

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Dustin Willis Webber <dustin.webber@gmail.com>
 
 # And thanks for contributions from:
 
+Andrew Wen <2060andrew@gmail.com>
 Christian Vespa <christian.vespa@silkrouteglobal.com>
 Eugene Bulkin <eugene@eugenebulkin.name>
 Shadab Zafar <dufferzafar0@gmail.com>

--- a/app/templates/helpers/message.js
+++ b/app/templates/helpers/message.js
@@ -29,16 +29,24 @@ define("templates/helpers/message", [
     },
 
     setColor: function (fg, bg) {
-      if (_.isNaN(fg)) return;
+      if (!_.isNaN(fg)) {
+        this.removeClass("irc-text-foreground-" + this.foreground);
+        this.addClass("irc-text-foreground-" + fg);
+        this.foreground = fg;
 
-      this.removeClass("irc-text-foreground-" + this.foreground);
-      this.addClass("irc-text-foreground-" + fg);
-      this.foreground = fg;
-
-      if (!_.isNaN(bg)) {
-        this.removeClass("irc-text-background-" + this.background);
-        this.addClass("irc-text-background-" + bg);
-        this.background = bg;
+        if (!_.isNaN(bg)) {
+          this.removeClass("irc-text-background-" + this.background);
+          this.addClass("irc-text-background-" + bg);
+          this.background = bg;
+        }
+        else if (this.background != null) {
+          this.removeClass("irc-text-background-" + this.background);
+          this.background = null;
+        }
+      }
+      else if (this.foreground != null) {
+        this.removeClass("irc-text-foreground-" + this.foreground);
+        this.foreground = null;
       }
     },
 
@@ -101,7 +109,9 @@ define("templates/helpers/message", [
 
           fg = parseInt(parts[0], 10);
 
-          i += String(fg).length;
+          if (!_.isNaN(fg)) {
+            i += String(fg).length;
+          }
 
           if (parts.length > 1) {
             bg = parseInt(parts[1], 10);


### PR DESCRIPTION
The ^C Character can also be used as a cancelling character for colors: i.e. ^C3MyColorText^Cnoncoloredtext
At the moment, Komanda will not only ignore the terminating ^C character, but it will also eat subsequent characters.

A demonstration of this was provided with the above input, as follows

![ss 2015-05-04 at 09 31 34](https://cloud.githubusercontent.com/assets/1640717/7467085/4302d8d6-f2a5-11e4-8866-abf808133c19.png)

This PR will fix both of the aforementioned issues