### PR TITLE
Gifv support, allow for video display toggle

### DIFF
--- a/app/lib/embed/image.js
+++ b/app/lib/embed/image.js
@@ -1,6 +1,6 @@
 define([], function () {
   return function bootstrapEmbedImage (register) {
-    register("image", /\.(gif|png|jpe?g)/i, {
+    register("image", /\.(gif[^v]|png|jpe?g)/i, {
       title: "Images",
       enabled: true
     },

--- a/app/lib/embed/video.js
+++ b/app/lib/embed/video.js
@@ -1,6 +1,8 @@
-define([], function () {
+define([
+  "hbs!templates/partials/show-more"
+], function (ShowMore) {
   return function bootstrapEmbedVideo (register) {
-    register("video", /\.webm$/i, {
+    register("video", /\.(webm|gifv)$/i, {
       title: "Videos",
       enabled: true,
       autoplay: { type: "checkbox", value: false },
@@ -8,14 +10,26 @@ define([], function () {
       volume: { type: "text", value: 0 }
     },
     function (link, settings) {
-      var video = $("<video src=\"" + link.url + "\" style=\"max-width: 600px; max-height: 400px\"></video>");
+      var url = link.url;
+      // Special handling for gifv, which should be rewritten to webm as it is not supported by the video tag
+      if (String(url).match(/\.gifv$/i)) {
+        url = (String(url).replace(/\.gifv$/i,".webm"));
+      }
+      var video = $("<video src=\"" + url + "\" style=\"max-width: 600px; max-height: 400px\"></video>");
 
       video.prop("controls", true)
            .prop("autoplay", settings.autoplay.value)
            .prop("loop", settings.loop.value)
            .prop("volume", settings.volume.value);
 
-      link.div.append(video);
+      link.div.append(ShowMore({
+        icon: "code",
+        title: "Toggle Attached Video",
+        ele: link.selector,
+        show: ".video-holder"
+      }));
+
+      link.div.append($(video).wrap("<div class=\"video-holder\"></div>").parent());
     });
   };
 });

--- a/app/styles/komanda.css
+++ b/app/styles/komanda.css
@@ -729,7 +729,8 @@ div.message .body .text .embed-items .show-more i{
 }
 
 div.message .body .text .embed-items .gist,
-div.message .body .text .embed-items .jsfiddle-holder{
+div.message .body .text .embed-items .jsfiddle-holder,
+div.message .body .text .embed-items .video-holder{
     display: none;
     margin-top: 10px;
 }


### PR DESCRIPTION
# Video display toggle
600x400 (at maximum size) is a very large amount of valuable screen real estate, not to mention people with less modern computers might not wish to have images displayed immediately. As such, this PR will introduce a toggle button akin to that used to handle gists/jsfiddle.

A screenshot of the end result is presented below: 
![ss 2015-05-05 at 08 51 03](https://cloud.githubusercontent.com/assets/1640717/7476706/3068647a-f304-11e4-978c-686cb0570a5d.jpg)

# Gifv support
Gifv is a file format specific to imgur ([details] (https://imgur.com/blog/2014/10/09/introducing-gifv/)) that is equivalent/converted at runtime by imgur's servers to mp4/webm depending on browser capabilities. Considering its widespread adoption (whereby all gifs uploaded to imgur are converted to gifvs due to superior performance) it makes sense to support this format. Even if support for this format is not desired, some changes ought to be made as at the moment the client processes it as a gif and displays a broken image icon.

**Current behaviour** 
Gifv is processed as a gif by image.js (why does the regex not include the $ terminating/empty character as in video.js out of curiousity? This was left unchanged as I was unsure whether this is intended behaviour) which then displays a broken image icon.

Edit: turns out the empty character being removed is intentional, so yeah good thing I left that there

**Implementation**
In the case of Komanda, it suffices to simply replace the gifv extension with webm (which imgur guarantees will be present) and process it as normal via adding it to video.js