### PR TITLE
Case Insensitive Tab Completion, Regex Highlighting

### DIFF
--- a/app/lib/deps/tab-complete.js
+++ b/app/lib/deps/tab-complete.js
@@ -29,7 +29,7 @@ define([
    * Add a single word to the trie.
    */
   Trie.prototype.word = function (word) {
-    var c = word.charAt(0);
+    var c = word.charAt(0).toLowerCase();
 
     if (!(c in this.children)) {
       this.children["" + c + ""] = new Trie(this.prefix + c);
@@ -145,7 +145,7 @@ define([
           value = value;
         }
 
-        var trie = root.find(value);
+        var trie = root.find(value.toLowerCase());
 
         if (trie) {
           // items[(items.length - 1)] = trie.uniquePrefix();

--- a/app/lib/settings.js
+++ b/app/lib/settings.js
@@ -41,7 +41,10 @@ define([
         highlight: true,
         pm: true,
         status: true,
-        badge: true
+        badge: true,
+        regexHighlight: "",
+        defaultRegexHighlight: "",
+        regexIgnoreNicks: ""
       },
       display: {
         timestamp: "MM/DD/YY hh:mm:ss",
@@ -52,7 +55,7 @@ define([
       sounds: {
         chat: false,
         pm: true,
-        hightlight: true
+        highlight: true
       },
       messages: {
         quit: "",

--- a/app/templates/settings/komanda.hbs
+++ b/app/templates/settings/komanda.hbs
@@ -28,6 +28,18 @@
     <label for="komanda-settings-notifications-badge">Badge Notifications</label>
     <input id="komanda-settings-notifications-badge" type="checkbox" name="notifications.badge">
   </div>
+
+  <div class="form-box">
+      <label for="komanda-settings-notifications-regexHighlight">Highlight Matching</label>
+      <input id="komanda-settings-notifications-regexHighlight" type="text" name="notifications.regexHighlight"
+             placeholder="Regex (Case Insensitive)" >
+  </div>
+
+  <div class="form-box">
+      <label for="komanda-settings-notifications-regexIgnoreNicks">Do Not Highlight Nicks</label>
+      <input id="komanda-settings-notifications-regexIgnoreNicks" type="text" name="notifications.regexIgnoreNicks"
+             placeholder="nick1, nick2, nick3">
+  </div>
 </div>
 
 <div class="settings-section-holder" id="komanda-settings-sounds" style="display:none;">


### PR DESCRIPTION
Implements case insensitive tab completion (differs from former PR in that it will preserve case of the other guy's nick upon tab completion), as well as regex based highlighting in addition to your own nick (which is enabled by default even with an empty regex string). Empty regex strings will default to your active nick.

In addition, implemented nick exclusions (which also supports wildcards via *): nicks that match will not highlight even if their message matches highlight's regex.
