### PR TITLE
Fix extra leading 0s causing problems in color processing

### DIFF
--- a/app/templates/helpers/message.js
+++ b/app/templates/helpers/message.js
@@ -110,14 +110,14 @@ define("templates/helpers/message", [
           fg = parseInt(parts[0], 10);
 
           if (!_.isNaN(fg)) {
-            i += String(fg).length;
+            i += new RegExp("(0*" + fg + ")").exec(parts[0])[1].length;
           }
 
           if (parts.length > 1) {
             bg = parseInt(parts[1], 10);
 
             if (!_.isNaN(bg)) {
-              i += String(bg).length + 1;
+              i += new RegExp("(0*" + bg + ")").exec(parts[1])[1].length + 1;
             }
           }
 

--- a/app/templates/helpers/message.js
+++ b/app/templates/helpers/message.js
@@ -110,14 +110,14 @@ define("templates/helpers/message", [
           fg = parseInt(parts[0], 10);
 
           if (!_.isNaN(fg)) {
-            i += new RegExp("(0*" + fg + ")").exec(parts[0])[1].length;
+            i += new RegExp("(0" + fg + "|" + fg + ")").exec(parts[0])[1].length;
           }
 
           if (parts.length > 1) {
             bg = parseInt(parts[1], 10);
 
             if (!_.isNaN(bg)) {
-              i += new RegExp("(0*" + bg + ")").exec(parts[1])[1].length + 1;
+              i += new RegExp("(0" + bg + "|" + bg + ")").exec(parts[1])[1].length + 1;
             }
           }
 

--- a/app/templates/helpers/message.js
+++ b/app/templates/helpers/message.js
@@ -107,14 +107,14 @@ define("templates/helpers/message", [
           var parts = message.substr(i + 1, 5).split(",");
           var fg, bg;
 
-          fg = parseInt(parts[0], 10);
+          fg = parseInt(parts[0].substring(0, 2), 10);
 
           if (!_.isNaN(fg)) {
             i += new RegExp("(0" + fg + "|" + fg + ")").exec(parts[0])[1].length;
           }
 
           if (parts.length > 1) {
-            bg = parseInt(parts[1], 10);
+            bg = parseInt(parts[1].substring(0, 2), 10);
 
             if (!_.isNaN(bg)) {
               i += new RegExp("(0" + bg + "|" + bg + ")").exec(parts[1])[1].length + 1;


### PR DESCRIPTION
i.e. ^C03 as opposed to ^C3 will cause the 0 to be eaten up and (green)3message to be displayed instead of (green) message as expected. Similar behaviour applies for background colors.